### PR TITLE
api: /jobs: don't 404 when no jobs were deleted

### DIFF
--- a/murdock/main.py
+++ b/murdock/main.py
@@ -166,9 +166,7 @@ async def finished_job_delete_handler(
     before: str, _: APIKey = Depends(_check_admin_permissions)
 ):
     query = JobQueryModel(before=before)
-    if not (jobs := await murdock.remove_finished_jobs(query)):
-        raise HTTPException(status_code=404, detail="Found no finished job to remove")
-    return jobs
+    return await murdock.remove_finished_jobs(query)
 
 
 @app.post(

--- a/murdock/tests/test_api.py
+++ b/murdock/tests/test_api.py
@@ -383,18 +383,15 @@ def test_restart_job_not_allowed(restart):
 
 
 @pytest.mark.usefixtures("admin_allowed")
-@pytest.mark.parametrize("result,code", [([], 404), ([test_job_finished], 200)])
+@pytest.mark.parametrize("result", [[], [test_job_finished]])
 @mock.patch("murdock.murdock.Murdock.remove_finished_jobs")
-def test_delete_jobs(remove, result, code):
+def test_delete_jobs(remove, result):
     remove.return_value = result
     before = "2021-08-16"
     response = client.delete(f"/jobs?before={before}")
-    assert response.status_code == code
+    assert response.status_code == 200
     remove.assert_called_with(JobQueryModel(before=before))
-    if result:
-        assert response.json() == [job.dict(exclude_none=True) for job in result]
-    else:
-        assert response.json() == {"detail": "Found no finished job to remove"}
+    assert response.json() == [job.dict(exclude_none=True) for job in result]
 
 
 @pytest.mark.usefixtures("admin_not_allowed")


### PR DESCRIPTION
... instead, just return 200 with an empty list.