### PR TITLE
murdock: Add basic prometheus instrumentation

### DIFF
--- a/murdock/main.py
+++ b/murdock/main.py
@@ -60,7 +60,6 @@ LOGGER.debug(
 murdock = Murdock(repository=GITHUB_CONFIG.repo)
 app = FastAPI(
     debug=GLOBAL_CONFIG.log_level == "DEBUG",
-    on_startup=[murdock.init],
     on_shutdown=[murdock.shutdown],
     title="Murdock API",
     description="This is the Murdock API",
@@ -80,6 +79,12 @@ app.mount(
     StaticFiles(directory=GLOBAL_CONFIG.work_dir, html=True, check_dir=False),
     name="results",
 )
+
+
+@app.on_event("startup")
+async def startup():
+    murdock.instrumentator.instrument(app).expose(app)
+    await murdock.init()
 
 
 @app.post("/github/webhook", include_in_schema=False)

--- a/murdock/murdock.py
+++ b/murdock/murdock.py
@@ -8,6 +8,7 @@ from typing import List, Optional, Union
 
 import websockets
 from fastapi import WebSocket
+from prometheus_fastapi_instrumentator import Instrumentator
 
 from murdock.config import GLOBAL_CONFIG, CI_CONFIG
 from murdock.log import LOGGER
@@ -73,6 +74,7 @@ class Murdock:
         self.fasttrack_queue: asyncio.Queue = asyncio.Queue()
         self.db = Database()
         self.notifier = Notifier()
+        self.instrumentator = Instrumentator()
 
     async def init(self):
         await self.db.init()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ motor
 httpx
 PyYaml
 aiosmtplib
+prometheus-fastapi-instrumentator


### PR DESCRIPTION
This adds python and HTTP statistics to be scraped by a prometheus (or other openmetrics collector) at the `/metrics` endpoint.