### PR TITLE
tox: add py to dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     pytest-cov
     pytest-asyncio
     pytest-xprocess
+    py
     -rrequirements.txt
 commands = pytest {posargs}
 


### PR DESCRIPTION
pytest dropped `py` as dependency and pytest-xprocess requires it as implicit dependency. As pytest-xprocess relied on pytest to pull it in it now errors when trying to run the murdock tests.

This commit adds `py` to the list of dependencies for tox. It can be reverted as soon as pytest-xprocess adds `py` to the dependency list.
See also: https://github.com/pytest-dev/pytest-xprocess/issues/110