### PR TITLE
murdock: Add prometheus counters for jobs

### DIFF
--- a/murdock/tests/conftest.py
+++ b/murdock/tests/conftest.py
@@ -2,6 +2,9 @@ import pytest
 from xprocess import ProcessStarter
 from murdock.murdock import Murdock
 
+from prometheus_client import REGISTRY
+
+
 @pytest.fixture
 def mongo(xprocess):
     class Starter(ProcessStarter):
@@ -15,8 +18,16 @@ def mongo(xprocess):
     xprocess.getinfo("mongo").terminate()
 
 
+# Flush the prometheus collector registry after tests
 @pytest.fixture
-def murdock(request):
+def clear_prometheus_registry():
+    collectors = list(REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        REGISTRY.unregister(collector)
+
+
+@pytest.fixture
+def murdock(request, clear_prometheus_registry):
     args = {}
     marker = request.node.get_closest_marker("murdock_args")
     if marker is not None:

--- a/murdock/tests/conftest.py
+++ b/murdock/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 from xprocess import ProcessStarter
-
+from murdock.murdock import Murdock
 
 @pytest.fixture
 def mongo(xprocess):
@@ -13,3 +13,12 @@ def mongo(xprocess):
     xprocess.ensure("mongo", Starter)
     yield
     xprocess.getinfo("mongo").terminate()
+
+
+@pytest.fixture
+def murdock(request):
+    args = {}
+    marker = request.node.get_closest_marker("murdock_args")
+    if marker is not None:
+        args = marker.args[0]
+    return Murdock(**args)

--- a/murdock/tests/test_murdock.py
+++ b/murdock/tests/test_murdock.py
@@ -35,6 +35,7 @@ from murdock.config import CI_CONFIG, GLOBAL_CONFIG, MurdockSettings
 )
 @mock.patch("murdock.database.Database.init")
 @mock.patch("murdock.murdock.Murdock.job_processing_task")
+@pytest.mark.usefixtures("clear_prometheus_registry")
 async def test_init(task, db_init, params, expected):
     murdock = Murdock(**params)
     await murdock.init()
@@ -388,7 +389,7 @@ async def test_handle_pr_event_action(
     allowed,
     queued_called,
     caplog,
-    murdock
+    murdock,
 ):
     caplog.set_level(logging.DEBUG, logger="murdock")
     event = pr_event.copy()
@@ -1060,7 +1061,7 @@ async def test_branch_manual_job(
     commit,
     fasttracked,
     scheduled,
-    murdock
+    murdock,
 ):
     fetch_branch_info.return_value = commit
     fetch_murdock_config.return_value = MurdockSettings()

--- a/murdock/tests/test_notify.py
+++ b/murdock/tests/test_notify.py
@@ -189,11 +189,10 @@ prinfo = PullRequestInfo(
 @mock.patch("httpx.AsyncClient.post")
 @mock.patch("aiosmtplib.send")
 async def test_notify(
-    mail_send, matrix_post, job, previous_state, new_state, matrix, mail, caplog
+    mail_send, matrix_post, job, previous_state, new_state, matrix, mail, caplog, murdock
 ):
     caplog.set_level(logging.DEBUG, logger="murdock")
     matrix_post.return_value = Response(200, text=json.dumps({"details": "ok"}))
-    murdock = Murdock()
     await murdock.init()
     notifier = Notifier()
     if previous_state is not None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,8 @@ addopts = -vv
           --cov-report=xml
           --cov-branch
 testpaths = murdock
+markers =
+    murdock_args: Arguments passed to the murdock constructor in the fixture
 
 [flake8]
 max-line-length = 80


### PR DESCRIPTION
This commit adds counters for the number of jobs added to the queue and
the result status of jobs.

Any job (re-)entering the queue should be counted, intentionally also
counting jobs that were requeued because of a change in the pull
request.

The other counter keeps track of the result of a job. This includes the
passed and errored label if the job completed the build, but also
stopped and canceled if the job was stopped before completing or if the
job was not started yet.

The number of builds currently in the queue should match the difference
between the queue counter and the job status counter