### PR TITLE
Database: Add abstract database class

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,9 @@ CI_FASTTRACK_LABELS=["CI: skip compile test", "Process: release backport"]
 # Murdock database configuration
 ##################################
 
+## Database backend type, supported "mongodb"
+MURDOCK_DB_TYPE=mongodb
+
 ## Directory containing the Mongo database files
 MONGODB_BD_DATA_DIR=/tmp/mongodb
 

--- a/murdock/config.py
+++ b/murdock/config.py
@@ -6,6 +6,7 @@ from pydantic import BaseSettings, Field, validator
 
 
 class DatabaseSettings(BaseSettings):
+    type: str = Field(env="MURDOCK_DB_TYPE", default="mongodb")
     host: str = Field(env="MURDOCK_DB_HOST", default="localhost")
     port: int = Field(env="MURDOCK_DB_PORT", default=27017)
     name: str = Field(env="MURDOCK_DB_NAME", default="murdock")

--- a/murdock/database/__init__.py
+++ b/murdock/database/__init__.py
@@ -1,0 +1,83 @@
+import abc
+from typing import List, Optional, Any
+
+from murdock.job import MurdockJob
+from murdock.models import JobModel, JobQueryModel
+from murdock.config import DB_CONFIG
+
+
+class Database(abc.ABC):
+    @abc.abstractmethod
+    def __init__(self):
+        """Constructor for the database backend."""
+
+    @abc.abstractmethod
+    async def init(self):
+        """Initialize the database backend."""
+
+    @abc.abstractmethod
+    def close(self):
+        """Close all database connections."""
+
+    @abc.abstractmethod
+    async def insert_job(self, job: MurdockJob):
+        """Insert a job into the database.
+
+        All properties of the job are serialized into a database-specific format and inserted as new record or document
+        into the database.
+
+        :param job: The job to insert.
+        """
+
+    @abc.abstractmethod
+    async def find_job(self, uid: str) -> Optional[MurdockJob]:
+        """Find a single job based on the job UID.
+
+        :param uid: The UID to find the job for.
+        :return: The job with the matching UID, None if no job is found.
+        """
+
+    @abc.abstractmethod
+    async def find_jobs(self, query: JobQueryModel) -> List[JobModel]:
+        """Find all jobs that match the given query.
+
+        :param query: JobQueryModel to match jobs on.
+        :returns: A list containing matching jobs.
+        """
+
+    @abc.abstractmethod
+    async def update_jobs(self, query: JobQueryModel, field: str, value: Any) -> int:
+        """Update a single field of the matching jobs.
+
+        :param query: JobQueryModel to match jobs on.
+        :param field: Field descriptor to update.
+        :param value: Value to set the field on.
+        :return: The number of updated records.
+        """
+
+    @abc.abstractmethod
+    async def count_jobs(self, query: JobQueryModel) -> int:
+        """Count the number of jobs matching the query.
+
+        :param query: JobQueryModel to match jobs on.
+        :return: The number of matching records.
+        """
+
+    @abc.abstractmethod
+    async def delete_jobs(self, query: JobQueryModel):
+        """Delete all matching jobs.
+
+        :param query: JobQueryModel to match jobs on.
+        """
+
+
+def database(database_type: str) -> Database:
+    if database_type == "mongodb":
+        from murdock.database import mongodb
+
+        return mongodb.MongoDatabase()
+    raise ValueError(f"Invalid database type specified: {database_type!r}")
+
+
+def database_from_env() -> Database:
+    return database(DB_CONFIG.type)

--- a/murdock/database/mongodb.py
+++ b/murdock/database/mongodb.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from typing import List, Optional
+from typing import List, Optional, Any
 
 import pymongo
 import motor.motor_asyncio as aiomotor
@@ -9,9 +9,10 @@ from murdock.config import DB_CONFIG
 from murdock.log import LOGGER
 from murdock.job import MurdockJob
 from murdock.models import CommitModel, JobModel, JobQueryModel, PullRequestInfo
+from murdock.database import Database
 
 
-class Database:
+class MongoDatabase(Database):
     def __init__(self):
         LOGGER.info("Initializing database connection")
         conn = aiomotor.AsyncIOMotorClient(
@@ -55,7 +56,7 @@ class Database:
         )
         return [MurdockJob.finished_model(job) for job in jobs]
 
-    async def update_jobs(self, query: JobQueryModel, field, value) -> int:
+    async def update_jobs(self, query: JobQueryModel, field: str, value: Any) -> int:
         return (
             await self.db.job.update_many(
                 query.to_mongodb_query(), {"$set": {field: value}}

--- a/murdock/murdock.py
+++ b/murdock/murdock.py
@@ -32,7 +32,7 @@ from murdock.github import (
     set_commit_status,
     fetch_murdock_config,
 )
-from murdock.database import Database
+from murdock.database import database_from_env
 from murdock.notify import Notifier
 
 
@@ -73,7 +73,7 @@ class Murdock:
         self.running: MurdockJobPool = MurdockJobPool(num_workers)
         self.queue: asyncio.Queue = asyncio.Queue()
         self.fasttrack_queue: asyncio.Queue = asyncio.Queue()
-        self.db = Database()
+        self.db = database_from_env()
         self.notifier = Notifier()
         self.instrumentator = Instrumentator()
 

--- a/murdock/tests/test_api.py
+++ b/murdock/tests/test_api.py
@@ -348,7 +348,7 @@ def test_update_job_status(
 )
 @mock.patch("murdock.murdock.Murdock.get_queued_jobs")
 @mock.patch("murdock.murdock.Murdock.get_running_jobs")
-@mock.patch("murdock.database.Database.find_jobs")
+@mock.patch("murdock.database.mongodb.MongoDatabase.find_jobs")
 def test_get_jobs_with_query(jobs, running, queued, query, call_arg):
     running.return_value = []
     queued.return_value = []

--- a/murdock/tests/test_database.py
+++ b/murdock/tests/test_database.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..database.mongodb import MongoDatabase as Database
+from ..database import Database, database, database_from_env
 from ..job import MurdockJob
 from ..models import CommitModel, PullRequestInfo, JobQueryModel
 
@@ -25,8 +25,8 @@ prinfo = PullRequestInfo(
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mongo")
-async def test_database(caplog):
-    db = Database()
+async def test_database_mongodb(caplog):
+    db = database("mongodb")
     await db.init()
     job_pr = MurdockJob(commit, pr=prinfo)
     await db.insert_job(job_pr)
@@ -65,3 +65,13 @@ async def test_database(caplog):
 
     db.close()
     assert "Closing database connection" in caplog.text
+
+
+def test_database_invalid():
+    with pytest.raises(ValueError):
+        database("postgremongosqlitedb")
+
+
+def test_database_config():
+    db = database_from_env()
+    assert isinstance(db, Database)

--- a/murdock/tests/test_database.py
+++ b/murdock/tests/test_database.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..database import Database
+from ..database.mongodb import MongoDatabase as Database
 from ..job import MurdockJob
 from ..models import CommitModel, PullRequestInfo, JobQueryModel
 

--- a/murdock/tests/test_murdock.py
+++ b/murdock/tests/test_murdock.py
@@ -34,7 +34,7 @@ from murdock.config import CI_CONFIG, GLOBAL_CONFIG, MurdockSettings
         ({}, GLOBAL_CONFIG.num_workers),
     ],
 )
-@mock.patch("murdock.database.Database.init")
+@mock.patch("murdock.database.mongodb.MongoDatabase.init")
 @mock.patch("murdock.murdock.Murdock.job_processing_task")
 @pytest.mark.usefixtures("clear_prometheus_registry")
 async def test_init(task, db_init, params, expected):


### PR DESCRIPTION
Paves the way for implementing alternative database back-ends.

There should be a better way to mock the individual database functions for a database back-end.