### PR TITLE
models: enforce [str, str] typing for environment dicts 

### DIFF
--- a/murdock/config.py
+++ b/murdock/config.py
@@ -79,7 +79,7 @@ class GlobalSettings(BaseSettings):
         env="MURDOCK_ACCEPTED_EVENTS", default=["push", "pull_request"]
     )
     num_workers: int = Field(env="MURDOCK_NUM_WORKERS", default=1)
-    custom_env: dict = Field(env="MURDOCK_CUSTOM_ENV", default=dict())
+    custom_env: dict[str, str] = Field(env="MURDOCK_CUSTOM_ENV", default=dict())
     log_level: str = Field(env="MURDOCK_LOG_LEVEL", default="INFO")
     max_finished_length_default: int = Field(
         env="MURDOCK_MAX_FINISHED_LENGTH_DEFAULT", default=25
@@ -138,7 +138,7 @@ class MurdockSettings(BaseSettings):
     push: PushSettings = Field(default=PushSettings())
     pr: PRSettings = Field(default=PRSettings())
     commit: CommitSettings = Field(default=CommitSettings())
-    env: dict = Field(default=dict())
+    env: dict[str, str] = Field(default=dict())
     failfast: bool = Field(default=False)
     artifacts: List[str] = Field(default=[])
     tasks: List[TaskSettings] = Field(default=[TaskSettings()])

--- a/murdock/models.py
+++ b/murdock/models.py
@@ -130,11 +130,11 @@ class JobModel(BaseModel):
     triggered_by: Optional[str] = Field(
         None, title="Github user who triggered the job creation"
     )
-    env: Optional[dict] = Field(
+    env: Optional[dict[str, str]] = Field(
         None,
         title="Dictionnary of environment variables attached to the job",
     )
-    user_env: Optional[dict] = Field(
+    user_env: Optional[dict[str, str]] = Field(
         None,
         title="User defined dictionnary of environment variables atteched to the job",
     )

--- a/murdock/tests/test_database.py
+++ b/murdock/tests/test_database.py
@@ -55,7 +55,7 @@ async def test_database(caplog):
     await db.delete_jobs(JobQueryModel(prnum=123))
     assert len(await db.find_jobs(JobQueryModel(prnum=123))) == 0
 
-    job_branch = MurdockJob(commit, ref="refs/heads/test", user_env={"TEST": 123})
+    job_branch = MurdockJob(commit, ref="refs/heads/test", user_env={"TEST": "123"})
     await db.insert_job(job_branch)
     search_job = await db.find_job(job_branch.uid)
     assert search_job is not None


### PR DESCRIPTION
As discussed offline, this forces the environment dicts to use only strings for the content.

The database test is adapted because the model would cast the value to a `str` causing the test to fail.