### PR TITLE
Traefik: Expose murdock frontend and traefik internal metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,7 @@ services:
     container_name: murdock-proxy-${COMPOSE_PROJECT_NAME}
     ports:
       - ${MURDOCK_PORT}:8081
+      - 9982:9982
     volumes:
       - ${PWD}/traefik:/etc/traefik
     environment:

--- a/traefik/http.yml
+++ b/traefik/http.yml
@@ -8,7 +8,8 @@ http:
         PathPrefix(`/job`) ||
         PathPrefix(`/results`) ||
         PathPrefix(`/ws`) ||
-        PathPrefix(`/openapi.json`)
+        PathPrefix(`/openapi.json`) ||
+        PathPrefix(`/metrics`)
       service: murdock
     to-frontend:
       middlewares:

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -1,10 +1,16 @@
 entryPoints:
   web:
     address: :8081
+  metrics:
+    address: :9982
 
 providers:
   file:
     filename: /etc/traefik/http.yml
+
+metrics:
+  prometheus:
+    entryPoint: metrics
 
 # log:
 #   level: DEBUG


### PR DESCRIPTION
This PR exposes the murdock frontend metrics and the traefik internal metrics so that they can be scraped by a prometheus instance