### PR TITLE
Murdock: add metrics for number of running jobs

### DIFF
--- a/murdock/job_containers.py
+++ b/murdock/job_containers.py
@@ -21,6 +21,10 @@ class MurdockJobListBase(ABC):
     def remove(self, job: MurdockJob) -> None:
         ...  # pragma: nocover
 
+    def len(self) -> int:
+        # Get the length of the generator without having to cast it to a list/tuple
+        return sum(1 for job in self.jobs if job is not None)
+
     def search_by_uid(self, uid: str) -> Optional[MurdockJob]:
         for job in self._jobs:
             if job is not None and job.uid == uid:

--- a/murdock/tests/test_murdock.py
+++ b/murdock/tests/test_murdock.py
@@ -207,8 +207,10 @@ async def test_schedule_multiple_jobs(
         await murdock.schedule_job(job)
 
     assert len(murdock.queued.jobs) == num_queued
+    assert murdock.job_queue_counter._value.get() == len(prnums)
     await asyncio.sleep(1)
     assert len(murdock.running.jobs) == 2
+    assert murdock.job_start_counter._value.get() == 2
     await asyncio.sleep(2.5)
     assert murdock.running.jobs.count(None) == free_slots
     await asyncio.sleep(1)


### PR DESCRIPTION
This adds a counter for the number of started jobs and a gauge to get the immediate number of jobs running.

As requested by @kaspar030 