### PR TITLE
murdock: Don't count stopped jobs twice 

### DIFF
--- a/murdock/murdock.py
+++ b/murdock/murdock.py
@@ -280,7 +280,6 @@ class Murdock:
             job.state = "errored"
 
         await job.stop()
-        self.job_status_counter.labels(status="stopped").inc()
         return job
 
     async def disable_jobs_matching(self, job: MurdockJob) -> List[MurdockJob]:

--- a/murdock/tests/test_murdock.py
+++ b/murdock/tests/test_murdock.py
@@ -150,6 +150,7 @@ async def test_schedule_single_job(
     assert job.status == {"status": "finished"}
     assert job.state == job_state
     assert status.call_count == 3
+    assert murdock.job_status_counter.labels(status=job_state)._value.get() == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Quick bug fix that caused negative load in the CI graphs because stopped jobs are counted twice.