### PR TITLE
Docker: Make uvicorn log level configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ USER murdock
 WORKDIR /var/lib/murdock
 EXPOSE 8000
 
-ENTRYPOINT ["uvicorn", "murdock.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload", "--reload-dir", "murdock"]
+ENTRYPOINT ["uvicorn", "murdock.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload", "--reload-dir", "murdock", "--log-level", "${UVICORN_LOG_LEVEL}"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
         - MURDOCK_NOTIFIER_MAIL_PASSWORD
         - MURDOCK_NOTIFIER_MATRIX_ROOM
         - MURDOCK_NOTIFIER_MATRIX_TOKEN
+        - UVICORN_LOG_LEVEL=info
         - CI_READY_LABEL
         - CI_FASTTRACK_LABELS
     volumes:


### PR DESCRIPTION
With this it can be configured locally via a docker-compose.override.yml containing:
```
services:
  murdock:
    environment:
        - UVICORN_LOG_LEVEL=warning
```