### PR TITLE
ci: test style before tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,10 +29,10 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install tox
         docker pull mongo:4.2.16
-    - name: Test with tox
-      run: tox -e test
     - name: Check style
       run: tox -e style
+    - name: Test with tox
+      run: tox -e test
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.10
       run: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This is a preference from my side. Usually style tests fail with my PRs while the tests run fine. swapping these to run the style tests first saves some time by failing faster (before the whole pytest suite is run and not after).

Let me know what you think and feel free to close if you disagree.