### PR TITLE
Dockerfile: remove uvicorn log level argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ USER murdock
 WORKDIR /var/lib/murdock
 EXPOSE 8000
 
-ENTRYPOINT ["uvicorn", "murdock.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload", "--reload-dir", "murdock", "--log-level", "${UVICORN_LOG_LEVEL}"]
+ENTRYPOINT ["uvicorn", "murdock.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload", "--reload-dir", "murdock"]


### PR DESCRIPTION
Passing the log level through environment variables is sufficient

reverts part of #26 