### PR TITLE
docker-compose: Add variant with only API services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@
 ## External port exposed
 MURDOCK_PORT=8000
 
+## External API port if exposed
+MURDOCK_API_PORT=8001
+
 ## External base url used to reach the Murdock UI/API
 MURDOCK_BASE_URL=http://localhost:8000
 

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -1,0 +1,16 @@
+services:
+  murdock:
+    extends:
+      file: docker-compose.yml
+      service: murdock
+    ports:
+      - ${MURDOCK_API_PORT}:8000
+  frontend-build:
+    extends:
+      file: docker-compose.yml
+      service: frontend-build
+    profiles: ["setup"]
+  mongo:
+    extends:
+      file: docker-compose.yml
+      service: mongo


### PR DESCRIPTION
This adds a docker-compose.api.yml that only starts the API services and the related services such as the database and building the frontend web files. This allows for running only the API components from docker and servicing the other components from external services