### PR TITLE
main: Add no-cache and etag to badge

### DIFF
--- a/murdock/main.py
+++ b/murdock/main.py
@@ -230,7 +230,12 @@ async def job_get_last_branch_badge_handler(branch: str):
     )
     env.globals.update(zip=zip)
     template = env.get_template("badge.svg.j2")
-    return Response(template.render(state=jobs[0].state), media_type="image/svg+xml")
+    headers = {"ETag": jobs[0].uid, "Cache-Control": "no-cache"}
+    return Response(
+        template.render(state=jobs[0].state),
+        headers=headers,
+        media_type="image/svg+xml",
+    )
 
 
 @app.post(


### PR DESCRIPTION
Github aggresively caches images for READMEs. This results in CI badges updating late or not after a different CI result. Adding the Content-Cache and ETag headers should prevent these badges from lingering too long in the cache.