### PR TITLE
 database: Add postgres backend 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,13 +49,13 @@ CI_FASTTRACK_LABELS=["CI: skip compile test", "Process: release backport"]
 # Murdock database configuration
 ##################################
 
-## Database backend type, supported "mongodb"
+## Database backend type, supported "mongodb" and "postgresql"
 MURDOCK_DB_TYPE=mongodb
 
 ## Directory containing the Mongo database files
 MONGODB_BD_DATA_DIR=/tmp/mongodb
 
-## Mongo database hostname
+## Murdock database hostname
 MURDOCK_DB_HOST=localhost
 
 ## Murdock database port, 0 for type default
@@ -63,6 +63,12 @@ MURDOCK_DB_PORT=0
 
 ## Name of the Mongo database
 MURDOCK_DB_NAME=murdock
+
+## Murdock database auth user
+MURDOCK_DB_AUTH_USER=murdock
+
+## Murdock database auth password
+MURDOCK_DB_AUTH_PASSWORD=hunter2
 
 #################################
 # Github integration parameters

--- a/.env.example
+++ b/.env.example
@@ -58,8 +58,8 @@ MONGODB_BD_DATA_DIR=/tmp/mongodb
 ## Mongo database hostname
 MURDOCK_DB_HOST=localhost
 
-## Mongo database port
-MURDOCK_DB_PORT=27017
+## Murdock database port, 0 for type default
+MURDOCK_DB_PORT=0
 
 ## Name of the Mongo database
 MURDOCK_DB_NAME=murdock

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,6 +29,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install tox==3.28.0 tox-envfile
         docker pull mongo:4.2.16
+        docker pull postgres:13
     - name: Test with tox
       run: tox -e test
     - name: Check style

--- a/murdock/config.py
+++ b/murdock/config.py
@@ -8,7 +8,7 @@ from pydantic import BaseSettings, Field, validator
 class DatabaseSettings(BaseSettings):
     type: str = Field(env="MURDOCK_DB_TYPE", default="mongodb")
     host: str = Field(env="MURDOCK_DB_HOST", default="localhost")
-    port: int = Field(env="MURDOCK_DB_PORT", default=27017)
+    port: int = Field(env="MURDOCK_DB_PORT", default=0)
     name: str = Field(env="MURDOCK_DB_NAME", default="murdock")
 
 

--- a/murdock/config.py
+++ b/murdock/config.py
@@ -10,6 +10,8 @@ class DatabaseSettings(BaseSettings):
     host: str = Field(env="MURDOCK_DB_HOST", default="localhost")
     port: int = Field(env="MURDOCK_DB_PORT", default=0)
     name: str = Field(env="MURDOCK_DB_NAME", default="murdock")
+    user: str = Field(env="MURDOCK_DB_AUTH_USER", default="murdock")
+    password: str = Field(env="MURDOCK_DB_AUTH_PASSWORD", default="hunter2")
 
 
 class GithubSettings(BaseSettings):

--- a/murdock/database/__init__.py
+++ b/murdock/database/__init__.py
@@ -16,7 +16,7 @@ class Database(abc.ABC):
         """Initialize the database backend."""
 
     @abc.abstractmethod
-    def close(self):
+    async def close(self):
         """Close all database connections."""
 
     @abc.abstractmethod
@@ -76,6 +76,12 @@ def database(database_type: str) -> Database:
         from murdock.database import mongodb
 
         return mongodb.MongoDatabase()
+
+    elif database_type == "postgresql":
+        from murdock.database import postgresql
+
+        return postgresql.PostgresDatabase()
+
     raise ValueError(f"Invalid database type specified: {database_type!r}")
 
 

--- a/murdock/database/mongodb.py
+++ b/murdock/database/mongodb.py
@@ -14,9 +14,10 @@ from murdock.database import Database
 
 class MongoDatabase(Database):
     def __init__(self):
-        LOGGER.info("Initializing database connection")
+        LOGGER.info("Initializing MongoDB database connection")
+        port = DB_CONFIG.port if DB_CONFIG.port else 27017
         conn = aiomotor.AsyncIOMotorClient(
-            f"mongodb://{DB_CONFIG.host}:{DB_CONFIG.port}",
+            f"mongodb://{DB_CONFIG.host}:{port}",
             maxPoolSize=5,
             io_loop=asyncio.get_event_loop(),
         )

--- a/murdock/database/mongodb.py
+++ b/murdock/database/mongodb.py
@@ -28,7 +28,7 @@ class MongoDatabase(Database):
             [("creation_time", pymongo.ASCENDING)], name="job_creation_time"
         )
 
-    def close(self):
+    async def close(self):
         LOGGER.info("Closing database connection")
         self.db.client.close()
 

--- a/murdock/database/postgresql.py
+++ b/murdock/database/postgresql.py
@@ -1,0 +1,399 @@
+from typing import Any, List, Optional, Tuple
+from datetime import datetime, timedelta, timezone
+
+from murdock.config import DB_CONFIG
+from murdock.log import LOGGER
+from murdock.job import MurdockJob
+from murdock.models import CommitModel, JobModel, JobQueryModel, PullRequestInfo
+from murdock.database import Database
+
+import asyncpg
+import orjson as json
+
+
+class PostgresDatabase(Database):
+    JOB_TO_COLUMN = {
+        "uid": "uuid",
+        "commit.sha": "commit_sha",
+        "commit.tree": "commit_tree",
+        "commit.message": "commit_message",
+        "commit.author": "commit_author",
+        "env": "environment",
+        "user_env": "user_environment",
+    }
+
+    @staticmethod
+    def _gen_simple_condition(
+        conditions: List[str],
+        args: List[str],
+        name: str,
+        value: Any,
+        nargs: int,
+        prefix: Optional[str] = None,
+        equality="=",
+    ) -> int:
+        if value is not None:
+            conditions.append(f"{name} {equality} ${nargs}")
+            if prefix is None:
+                args.append(value)
+            else:
+                args.append(prefix + value)
+            nargs += 1
+        return nargs
+
+    @staticmethod
+    def _bool2not(val: bool) -> str:
+        return "NOT" if not val else ""
+
+    @classmethod
+    def _gen_condition_clause(
+        cls, query: JobQueryModel, nargs=1
+    ) -> Tuple[str, List[Any]]:
+        conditions: List[str] = []
+        args: List[Any] = []
+        before = None
+        after = None
+        if query.before is not None:
+            before = datetime.strptime(query.before, "%Y-%m-%d")
+        if query.after is not None:
+            after = datetime.strptime(query.after, "%Y-%m-%d")
+        nargs = cls._gen_simple_condition(conditions, args, "uuid", query.uid, nargs)
+        nargs = cls._gen_simple_condition(
+            conditions, args, "prinfo_number", query.prnum, nargs
+        )
+        nargs = cls._gen_simple_condition(
+            conditions, args, "ref", query.branch, nargs, prefix="refs/heads/"
+        )
+        nargs = cls._gen_simple_condition(
+            conditions, args, "ref", query.tag, nargs, prefix="refs/tags/"
+        )
+        nargs = cls._gen_simple_condition(conditions, args, "ref", query.ref, nargs)
+        nargs = cls._gen_simple_condition(
+            conditions, args, "commit_sha", query.sha, nargs
+        )
+        nargs = cls._gen_simple_condition(
+            conditions, args, "commit_tree", query.tree, nargs
+        )
+        nargs = cls._gen_simple_condition(
+            conditions, args, "commit_author", query.author, nargs
+        )
+        nargs = cls._gen_simple_condition(
+            conditions, args, "creation_time", after, nargs, equality=">"
+        )
+        nargs = cls._gen_simple_condition(
+            conditions, args, "creation_time", before, nargs, equality="<"
+        )
+        if query.is_branch is not None:
+            conditions.append(
+                f"{cls._bool2not(query.is_branch)} ref LIKE 'refs/heads/%'"
+            )
+        if query.is_tag is not None:
+            conditions.append(f"{cls._bool2not(query.is_tag)} ref LIKE 'refs/tags%'")
+        if query.is_pr is not None:
+            conditions.append(f"prinfo IS {cls._bool2not(not query.is_pr)} NULL")
+        if query.states is not None:
+            conditions.append(f"state = ANY(${nargs}::result_state[])")
+            args.append(query.states.split())
+            nargs += 1
+        if query.prstates is not None:
+            conditions.append(f"prinfo_state = ANY(${nargs}::pr_state[])")
+            args.append(query.prstates.split())
+            nargs += 1
+        if len(conditions) == 0:
+            return "", []
+        return "WHERE " + " AND ".join(conditions), args
+
+    def __init__(self):
+        self.db_pool = None
+
+    @staticmethod
+    async def _load_extensions(conn):
+        await conn.execute(
+            """
+            CREATE EXTENSION IF NOT EXISTS hstore;
+            """
+        )
+
+    async def _create_schema(self):
+        async with self.db_pool.acquire() as conn:
+            await self._load_extensions(conn)
+
+            # Conditionally add new enum types
+            await conn.execute(
+                """
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'result_state') THEN
+                        CREATE TYPE result_state AS ENUM
+                            ('queued', 'running', 'passed', 'errored', 'stopped');
+                    END IF;
+                END
+                $$;
+                """
+            )
+            await conn.execute(
+                """
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'pr_state') THEN
+                        CREATE TYPE pr_state AS ENUM
+                            ('open', 'closed');
+                    END IF;
+                END
+                $$;
+                """
+            )
+
+            # Create main table
+            await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS jobs(
+                    id serial PRIMARY KEY,
+                    uuid UUID UNIQUE NOT NULL,
+                    creation_time TIMESTAMP WITH TIME ZONE NOT NULL,
+                    start_time TIMESTAMP WITH TIME ZONE,
+                    commit_sha TEXT,
+                    commit_tree TEXT,
+                    commit_message TEXT,
+                    commit_author TEXT,
+                    prinfo_number INTEGER,
+                    prinfo_state pr_state,
+                    ref TEXT,
+                    output TEXT,
+                    output_text_url TEXT,
+                    environment hstore,
+                    user_environment hstore,
+                    prinfo jsonb,
+                    fasttracked BOOLEAN,
+                    runtime INTERVAL,
+                    status jsonb,
+                    state result_state,
+                    trigger TEXT,
+                    triggered_by TEXT,
+                    artifacts TEXT[] DEFAULT '{}'::TEXT[]
+                    );
+                """
+            )
+
+            # Create all indexes used with search queries
+            await conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS prinfo_number_idx ON jobs (prinfo_number);
+                CREATE INDEX IF NOT EXISTS pr_state_idx ON jobs USING HASH (prinfo_state);
+                CREATE INDEX IF NOT EXISTS creation_time_idx ON jobs (creation_time);
+                CREATE INDEX IF NOT EXISTS ref_idx ON jobs USING HASH (ref);
+                CREATE INDEX IF NOT EXISTS ref_branch_idx ON jobs USING HASH ((ref LIKE 'refs/head/%'));
+                CREATE INDEX IF NOT EXISTS ref_tag_idx ON jobs USING HASH ((ref LIKE 'refs/tag/%'));
+                CREATE INDEX IF NOT EXISTS state_idx ON jobs USING HASH (state);
+                CREATE INDEX IF NOT EXISTS commit_sha_idx ON jobs USING HASH (commit_sha);
+                CREATE INDEX IF NOT EXISTS commit_tree_idx ON jobs USING HASH (commit_tree);
+                CREATE INDEX IF NOT EXISTS commit_author_idx ON jobs USING HASH (commit_author);
+                CREATE INDEX IF NOT EXISTS prinfo_idx ON jobs USING HASH ((prinfo IS NOT NULL));
+                """
+            )
+
+    @staticmethod
+    async def _init_conn(conn: asyncpg.Connection):
+        # Automatically encode/decode json type objects
+        await conn.set_type_codec(
+            "jsonb",
+            encoder=lambda x: json.dumps(x).decode(encoding="utf-8", errors="strict"),
+            decoder=json.loads,
+            schema="pg_catalog",
+        )
+        # Register hstore to dict encoding/decoding
+        await conn.set_builtin_type_codec(
+            "hstore",
+            codec_name="pg_contrib.hstore",
+        )
+
+    async def _setup_conn(self, conn: asyncpg.Connection):
+        conn.add_termination_listener(self._termination_listener)
+
+    def _termination_listener(self, conn):
+        LOGGER.warning(f"Lost connection to PostgreSQL database {conn}")
+
+    async def init(self):
+        port = DB_CONFIG.port if DB_CONFIG.port else 5432
+        LOGGER.info(
+            f"Connecting to postgres on {DB_CONFIG.host}:{port} with {DB_CONFIG.user} on {DB_CONFIG.name}"
+        )
+        conn_args = {
+            "host": DB_CONFIG.host,
+            "port": port,
+            "user": DB_CONFIG.user,
+            "database": DB_CONFIG.name,
+            "password": DB_CONFIG.password,
+        }
+
+        LOGGER.info("Initializing PostgreSQL database connection")
+        # Register extensions before using them in the pool init
+        temp_conn = await asyncpg.connect(**conn_args)
+        await self._load_extensions(temp_conn)
+        await temp_conn.close()
+
+        self.db_pool = await asyncpg.create_pool(
+            init=self._init_conn,
+            setup=self._setup_conn,
+            **conn_args,
+            server_settings={
+                "jit": "off"
+            },  # Current postgres performance is abysmal with jit enabled
+        )
+        await self._create_schema()
+
+    async def close(self):
+        try:
+            await self.db_pool.close()
+        except AttributeError:
+            LOGGER.error("Attempting to close database pool before initializing it")
+
+    async def insert_job(self, job: MurdockJob):
+        return await self.insert_job_model(job.model())
+
+    async def insert_job_model(self, job: JobModel):
+        prinfo_number = None
+        prinfo_state = None
+        prinfo = None
+        if job.prinfo is not None:
+            prinfo = job.prinfo.dict()
+            prinfo_number = prinfo.pop("number")
+            prinfo_state = prinfo.pop("state")
+        runtime = timedelta(seconds=job.runtime) if job.runtime is not None else None
+
+        async with self.db_pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO jobs(uuid, creation_time, start_time, commit_sha,
+                    commit_tree, commit_message, commit_author, prinfo_number, prinfo_state, ref,
+                    output, output_text_url, environment, user_environment, prinfo, fasttracked,
+                    runtime, status, state, trigger, triggered_by, artifacts)
+                    VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22);
+                """,
+                job.uid,
+                datetime.fromtimestamp(job.creation_time, tz=timezone.utc),
+                datetime.fromtimestamp(job.start_time, tz=timezone.utc),
+                job.commit.sha,
+                job.commit.tree,
+                job.commit.message,
+                job.commit.author,
+                prinfo_number,
+                prinfo_state,
+                job.ref,
+                job.output,
+                job.output_text_url,
+                job.env,
+                job.user_env,
+                prinfo,
+                job.fasttracked,
+                runtime,
+                job.status,
+                job.state,
+                job.trigger,
+                job.triggered_by,
+                job.artifacts,
+            )
+
+    @classmethod
+    def _commit_from_entry(cls, entry: asyncpg.Record) -> CommitModel:
+        return CommitModel(
+            sha=entry["commit_sha"],
+            tree=entry["commit_tree"],
+            message=entry["commit_message"],
+            author=entry["commit_author"],
+        )
+
+    @classmethod
+    def _prinfo_from_entry(cls, entry: asyncpg.Record) -> Optional[PullRequestInfo]:
+        if entry["prinfo"] is None:
+            return None
+        return PullRequestInfo(
+            number=entry["prinfo_number"],
+            state=entry["prinfo_state"],
+            **entry["prinfo"],
+        )
+
+    async def find_job(self, uid: str) -> Optional[MurdockJob]:
+        async with self.db_pool.acquire() as conn:
+            entry = await conn.fetchrow(
+                """
+                SELECT * FROM jobs WHERE uuid = $1
+                """,
+                uid,
+            )
+        if not entry:
+            LOGGER.warning(f"Cannot find job matching uid '{uid}'")
+            return None
+        commit = self._commit_from_entry(entry)
+        prinfo = self._prinfo_from_entry(entry)
+        ref = entry["ref"]
+        return MurdockJob(
+            commit, pr=prinfo, ref=ref, user_env=entry["user_environment"]
+        )
+
+    async def find_jobs(self, query: JobQueryModel) -> List[JobModel]:
+        condition, args = self._gen_condition_clause(query)
+        limit_condition = (
+            f" LIMIT {int(query.limit)}" if query.limit is not None else ""
+        )
+        sql_query = (  # nosec - Only uses argument in query (keep it that way!)
+            "SELECT * FROM jobs "
+            + condition
+            + " ORDER BY creation_time DESC"
+            + limit_condition
+        )
+
+        async with self.db_pool.acquire() as conn:
+            entries = await conn.fetch(sql_query, *args)
+        return [
+            JobModel(
+                uid=entry["uuid"].hex,
+                commit=self._commit_from_entry(entry),
+                ref=entry["ref"],
+                prinfo=self._prinfo_from_entry(entry),
+                creation_time=entry["creation_time"].timestamp(),
+                start_time=entry["start_time"].timestamp(),
+                fasttracked=entry["fasttracked"],
+                status=entry["status"],
+                state=entry["state"],
+                output=entry["output"],
+                output_text_url=entry["output_text_url"],
+                runtime=entry["runtime"].total_seconds(),
+                trigger=entry["trigger"],
+                triggered_by=entry["triggered_by"],
+                env=entry["environment"],
+                artifacts=entry["artifacts"],
+                user_env=entry["user_environment"],
+            )
+            for entry in entries
+        ]
+
+    @classmethod
+    def _to_postgres_field(cls, field: str) -> str:
+        return cls.JOB_TO_COLUMN.get(field, field).replace("'", "''")
+
+    async def update_jobs(self, query: JobQueryModel, field: str, value: Any) -> int:
+        postgres_field = self._to_postgres_field(field)
+        condition, args = self._gen_condition_clause(query, nargs=2)
+
+        sql_query = (  # nosec - postgres_field is protected and the rest is supplied as argument
+            f"UPDATE jobs SET {postgres_field} = $1 " + condition
+        )
+        async with self.db_pool.acquire() as conn:
+            count = await conn.execute(sql_query, value, *args)
+        return int(count.split()[1])
+
+    async def count_jobs(self, query: JobQueryModel) -> int:
+        condition, args = self._gen_condition_clause(query, nargs=1)
+        sql_query = (  # nosec - Only static strings
+            "SELECT COUNT(1) FROM jobs " + condition
+        )
+        async with self.db_pool.acquire() as conn:
+            count = await conn.fetchval(sql_query, *args)
+        return count
+
+    async def delete_jobs(self, query: JobQueryModel):
+        condition, args = self._gen_condition_clause(query, nargs=1)
+        sql_query = "DELETE FROM jobs " + condition  # nosec - Only static strings
+        async with self.db_pool.acquire() as conn:
+            await conn.execute(sql_query, *args)

--- a/murdock/murdock.py
+++ b/murdock/murdock.py
@@ -32,7 +32,7 @@ from murdock.github import (
     set_commit_status,
     fetch_murdock_config,
 )
-from murdock.database import database_from_env
+from murdock.database import database
 from murdock.notify import Notifier
 
 
@@ -59,6 +59,7 @@ class Murdock:
         cancel_on_update: bool = GLOBAL_CONFIG.cancel_on_update,
         store_stopped_jobs: bool = GLOBAL_CONFIG.store_stopped_jobs,
         enable_notifications: bool = GLOBAL_CONFIG.enable_notifications,
+        database_type: str = DB_CONFIG.type,
     ):
         self.base_url: str = base_url
         self.repository: Optional[str] = repository
@@ -73,9 +74,9 @@ class Murdock:
         self.running: MurdockJobPool = MurdockJobPool(num_workers)
         self.queue: asyncio.Queue = asyncio.Queue()
         self.fasttrack_queue: asyncio.Queue = asyncio.Queue()
-        self.db = database_from_env()
         self.notifier = Notifier()
         self.instrumentator = Instrumentator()
+        self.db = database(database_type)
 
         # Prometheus / openmetrics initialization
         self.job_queue_counter = prometheus_client.Counter(

--- a/murdock/murdock.py
+++ b/murdock/murdock.py
@@ -11,7 +11,7 @@ from fastapi import WebSocket
 from prometheus_fastapi_instrumentator import Instrumentator
 import prometheus_client
 
-from murdock.config import GLOBAL_CONFIG, CI_CONFIG
+from murdock.config import GLOBAL_CONFIG, CI_CONFIG, DB_CONFIG
 from murdock.log import LOGGER
 from murdock.job import MurdockJob
 from murdock.job_containers import MurdockJobList, MurdockJobPool
@@ -130,7 +130,7 @@ class Murdock:
 
     async def shutdown(self):
         LOGGER.info("Shutting down Murdock")
-        self.db.close()
+        await self.db.close()
         for ws in self.clients:
             LOGGER.debug(f"Closing websocket {ws}")
             await ws.close()

--- a/murdock/tests/conftest.py
+++ b/murdock/tests/conftest.py
@@ -8,7 +8,7 @@ from prometheus_client import REGISTRY
 
 
 @pytest.fixture
-def mongo(xprocess):
+def mongodb(xprocess):
     class Starter(ProcessStarter):
         pattern = "index build: done building index*"
         args = ["docker", "run", "--rm", "-p", "27017:27017", "mongo:4.2.16"]

--- a/murdock/tests/conftest.py
+++ b/murdock/tests/conftest.py
@@ -1,3 +1,4 @@
+import time
 import pytest
 from xprocess import ProcessStarter
 from murdock.murdock import Murdock
@@ -18,6 +19,22 @@ def mongodb(xprocess):
     xprocess.ensure("mongo", Starter)
     yield
     xprocess.getinfo("mongo").terminate()
+
+
+@pytest.fixture
+def postgresql(xprocess):
+    class Starter(ProcessStarter):
+        pattern = ".*database system is ready to accept connections"
+        args = ["docker", "run", "--rm", "-e", "POSTGRES_PASSWORD=hunter2",
+                "-e", "POSTGRES_USER=murdock", "-e", "PGDATA=/tmp/postgres",
+                "-p", "5432:5432", "postgres:13"]
+        terminate_on_interrupt = True
+        timeout = 10
+
+    xprocess.ensure("postgres", Starter)
+    time.sleep(1)
+    yield
+    xprocess.getinfo("postgres").terminate()
 
 
 # Flush the prometheus collector registry after tests

--- a/murdock/tests/test_database.py
+++ b/murdock/tests/test_database.py
@@ -24,7 +24,7 @@ prinfo = PullRequestInfo(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("mongo")
+@pytest.mark.usefixtures("mongodb")
 async def test_database_mongodb(caplog):
     db = database("mongodb")
     await db.init()

--- a/murdock/tests/test_database_mongodb.py
+++ b/murdock/tests/test_database_mongodb.py
@@ -63,7 +63,7 @@ async def test_database_mongodb(caplog):
     assert search_job.pr == job_branch.pr
     assert search_job.user_env == job_branch.user_env
 
-    db.close()
+    await db.close()
     assert "Closing database connection" in caplog.text
 
 

--- a/murdock/tests/test_database_postgresql.py
+++ b/murdock/tests/test_database_postgresql.py
@@ -1,0 +1,87 @@
+import pytest
+import random
+from datetime import timedelta
+
+from ..database import database
+from ..job import MurdockJob
+from ..models import CommitModel, PullRequestInfo, JobQueryModel
+import uuid
+
+commit = CommitModel(
+    sha="test_commit", tree="test_tree", message="test message", author="test_user"
+)
+prinfo = PullRequestInfo(
+    title="test",
+    number=123,
+    merge_commit="test_merge_commit",
+    user="test_user",
+    url="test_url",
+    base_repo="test_base_repo",
+    base_branch="test_base_branch",
+    base_commit="test_base_commit",
+    base_full_name="test_base_full_name",
+    mergeable=True,
+    labels=["test"],
+    state="open",
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("postgresql")
+async def test_database_postgres(caplog):
+    print("starting database test")
+    prnum = random.randint(1, 60000)
+    prinfo.number = prnum
+    db = database("postgresql")
+    await db.init()
+    job_pr = MurdockJob(commit, pr=prinfo)
+    await db.insert_job(job_pr)
+    search_job = await db.find_job(uuid.uuid4().hex)
+    assert search_job is None
+    search_job = await db.find_job(job_pr.uid)
+    assert search_job is not None
+    assert search_job.commit == job_pr.commit
+    assert search_job.pr == job_pr.pr
+    assert search_job.user_env is None
+
+    search_jobs = await db.find_jobs(JobQueryModel(prnum=600001))
+    assert len(search_jobs) == 0
+    assert await db.count_jobs(JobQueryModel(prnum=600001)) == 0
+
+    assert await db.count_jobs(JobQueryModel(prnum=prnum)) == 1
+    search_jobs = await db.find_jobs(JobQueryModel(prnum=prnum, prstates="open"))
+    assert len(search_jobs) == 1
+    assert search_jobs[0].commit == job_pr.commit
+    assert search_jobs[0].prinfo == job_pr.pr
+
+    assert await db.update_jobs(JobQueryModel(prnum=prnum), "commit.sha", "456") == 1
+    search_jobs = await db.find_jobs(JobQueryModel(prnum=prnum))
+    assert search_jobs[0].commit.sha == "456"
+
+    await db.delete_jobs(JobQueryModel(prnum=prnum))
+    assert len(await db.find_jobs(JobQueryModel(prnum=prnum))) == 0
+
+    job_branch = MurdockJob(commit, ref="refs/heads/test", user_env={"TEST": "123"})
+    await db.insert_job(job_branch)
+    search_job = await db.find_job(job_branch.uid)
+    assert search_job is not None
+    assert search_job.commit == job_branch.commit
+    assert search_job.pr == job_branch.pr
+    assert search_job.user_env == job_branch.user_env
+    assert job_branch.model() == (await db.find_jobs(JobQueryModel(is_branch=True)))[0]
+    assert job_branch.model() == (await db.find_jobs(JobQueryModel(branch="test")))[0]
+    time_after = job_branch.creation_time - timedelta(days=1)
+    assert (
+        job_branch.model()
+        == (await db.find_jobs(JobQueryModel(is_tag=False, uid=job_branch.uid)))[0]
+    )
+    assert (
+        job_branch.model()
+        == (await db.find_jobs(JobQueryModel(is_pr=False, uid=job_branch.uid)))[0]
+    )
+    assert (
+        job_branch.model()
+        == (await db.find_jobs(JobQueryModel(after=time_after.strftime("%Y-%m-%d"))))[0]
+    )
+
+    await db.close()

--- a/murdock/tests/test_murdock.py
+++ b/murdock/tests/test_murdock.py
@@ -911,6 +911,9 @@ async def test_handle_push_event_unsupported_repo(caplog, murdock):
 async def test_handle_job_status_data(notify, search, job_found, data, called, murdock):
     status_data = {"status": data}
     search.return_value = job_found
+    if job_found is not None:
+        # handle_job_status_data updates the object, reset the status to the default here
+        job_found.status = {"status": ""}
     await murdock.handle_job_status_data("1234", status_data)
     if called is True:
         status_data.update({"cmd": "status", "uid": job_found.uid})

--- a/murdock/tests/test_murdock.py
+++ b/murdock/tests/test_murdock.py
@@ -8,6 +8,7 @@ from fastapi import WebSocket
 from prometheus_client import REGISTRY
 
 from murdock.murdock import Murdock
+from murdock.database import Database
 from murdock.job import MurdockJob
 from unittest import mock
 
@@ -35,13 +36,14 @@ from murdock.config import CI_CONFIG, GLOBAL_CONFIG, MurdockSettings
         ({}, GLOBAL_CONFIG.num_workers),
     ],
 )
-@mock.patch("murdock.database.mongodb.MongoDatabase.init")
 @mock.patch("murdock.murdock.Murdock.job_processing_task")
 @pytest.mark.usefixtures("clear_prometheus_registry")
-async def test_init(task, db_init, params, expected):
+async def test_init(task, params, expected):
     murdock = Murdock(**params)
+    mock_db = mock.Mock(spec=Database)
+    murdock.db = mock_db
     await murdock.init()
-    db_init.assert_called_once()
+    murdock.db.init.assert_called_once()
     assert task.call_count == expected
 
 
@@ -63,7 +65,6 @@ exit {run_ret}
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("mongo")
 @pytest.mark.parametrize(
     "ret,job_state,comment_on_pr",
     [
@@ -164,7 +165,6 @@ async def test_schedule_single_job(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("mongo")
 @pytest.mark.parametrize(
     "prnums,num_queued,free_slots",
     [
@@ -229,7 +229,6 @@ async def test_schedule_multiple_jobs(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("mongo")
 @mock.patch("murdock.murdock.set_commit_status", mock.AsyncMock())
 @pytest.mark.murdock_args({"num_workers": 1})
 async def test_schedule_multiple_jobs_with_fasttracked(tmpdir, caplog, murdock):
@@ -980,7 +979,6 @@ async def test_remove_job(queued, running, remove_dir, murdock_mockdb):
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("mongo")
 async def test_remove_jobs(murdock):
     await murdock.init()
     job1 = MurdockJob(

--- a/murdock/tests/test_notify.py
+++ b/murdock/tests/test_notify.py
@@ -40,7 +40,6 @@ def clear_prometheus_registry():
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("mongo")
 @pytest.mark.parametrize(
     "job,previous_state,new_state,matrix,mail",
     [

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ httpx
 PyYaml
 aiosmtplib
 prometheus-fastapi-instrumentator
+asyncpg
+orjson


### PR DESCRIPTION
This adds support for Postgresql as relational database backend for the persistent job storage. The implementation makes use of [`asyncpg`](https://pypi.org/project/asyncpg/). Queries are manually written, but can be adapted to an ORM such as sqlalchemy in the future.  There is only two spots where arguments are directly interpolated into the query string: the `LIMIT` clause in the `find_jobs` and the column name in the update. In all other cases the code uses query arguments to prevent SQL injection.

The tests are adapted to run with both postgres and mongodb where applicable. Only the API test runs with only mongodb (as it is the default).

A number of small commits can be split out from this PR if needed, such as 65b368b9a65ac770a1ce700a1bf47df03da5a604, aa9f59dd8db05fa2812476f6eedd37335bbf8b1d, 053707021c54837a106254c0fa09f3a2f8c0c124 and 3b954170531c17d4f4d1f649cf3a19a0fb74eb0c.

Depends on #13 and #17 