### PR TITLE
mongodb: Make compatible with gunicorn

### DIFF
--- a/murdock/database/mongodb.py
+++ b/murdock/database/mongodb.py
@@ -20,6 +20,7 @@ class MongoDatabase(Database):
             maxPoolSize=5,
             io_loop=asyncio.get_event_loop(),
         )
+        conn.get_io_loop = asyncio.get_event_loop
         self.db = conn[DB_CONFIG.name]
 
     async def init(self):


### PR DESCRIPTION
This resolves a small issue with motor. In turn Murdock can also be started with gunicorn:

```
gunicorn murdock.main:app --worker-class uvicorn.workers.UvicornWorker
```

Without this patch the coroutines from motor would attach to a different event loop, resulting in a runtime error.