### PR TITLE
Rewrite logging to structured log format

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,6 +26,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt install build-essential libsystemd-dev libpython3-dev
         python -m pip install --upgrade pip
         python -m pip install tox==3.28.0 tox-envfile
         docker pull mongo:4.2.16

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="alexandre.abadie@inria.fr"
 # Install tools required by the build.sh script
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        libsystemd-dev \
         python3-pip \
         docker.io \
         && \
@@ -28,4 +29,4 @@ USER murdock
 WORKDIR /var/lib/murdock
 EXPOSE 8000
 
-ENTRYPOINT ["uvicorn", "murdock.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload", "--reload-dir", "murdock"]
+ENTRYPOINT ["./murdock.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ LABEL maintainer="alexandre.abadie@inria.fr"
 # Install tools required by the build.sh script
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        build-essential \
         libsystemd-dev \
+	libpython3-dev \
         python3-pip \
         docker.io \
         && \
@@ -16,6 +18,12 @@ COPY requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install --upgrade pip && \
     python3 -m pip install -r /tmp/requirements.txt && \
     rm -f /tmp/requirements.txt
+
+# No need to keep these around
+RUN apt purge -y --auto-remove \
+        build-essential \
+        libsystemd-dev \
+	libpython3-dev
 
 RUN mkdir -p /var/lib/{murdock,murdock-data}
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,13 @@ Launch the MongoDB service:
 $ docker-compose up mongo-dev
 ```
 
-Launch the `uvicorn` server with the `--reload` option:
+Launch the Murdock application with:
+
+```
+$ ./murdock.py
+```
+
+Or via `uvicorn` server with the `--reload` option:
 
 ```
 $ uvicorn murdock.main:app --reload --reload-dir murdock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:rw
       - /usr/bin/docker:/usr/bin/docker
+      - /run/systemd/journal/socket:/run/systemd/journal/socket
       - ./murdock:/var/lib/murdock/murdock
       - ${MURDOCK_WORK_DIR}:/var/lib/murdock-data
       - ${MURDOCK_SCRIPTS_DIR}:/var/lib/murdock-scripts

--- a/murdock.py
+++ b/murdock.py
@@ -4,5 +4,10 @@ import uvicorn
 from murdock.log import stdlib_config
 
 if __name__ == "__main__":
-    uvicorn.run("murdock.main:app", reload=True, reload_dirs="murdock")
-    uvicorn.run("murdock.main:app", reload=True, reload_dirs="murdock", host="0.0.0.0")
+    uvicorn.run(
+        "murdock.main:app",
+        reload=True,
+        reload_dirs="murdock",
+        host="0.0.0.0",
+        log_config=stdlib_config,
+    )

--- a/murdock.py
+++ b/murdock.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+import uvicorn
+from murdock.log import stdlib_config
+
+if __name__ == "__main__":
+    uvicorn.run("murdock.main:app", reload=True, reload_dirs="murdock")
+    uvicorn.run("murdock.main:app", reload=True, reload_dirs="murdock", host="0.0.0.0")

--- a/murdock/config.py
+++ b/murdock/config.py
@@ -83,7 +83,8 @@ class GlobalSettings(BaseSettings):
     )
     num_workers: int = Field(env="MURDOCK_NUM_WORKERS", default=1)
     custom_env: dict[str, str] = Field(env="MURDOCK_CUSTOM_ENV", default=dict())
-    log_level: str = Field(env="MURDOCK_LOG_LEVEL", default="INFO")
+    log_level: str = Field(env="MURDOCK_LOG_LEVEL", default="DEBUG")
+    log_output: str = Field(env="MURDOCK_LOG_OUTPUT", default="console")
     max_finished_length_default: int = Field(
         env="MURDOCK_MAX_FINISHED_LENGTH_DEFAULT", default=25
     )

--- a/murdock/log.py
+++ b/murdock/log.py
@@ -1,20 +1,81 @@
-import logging
-
-from uvicorn.logging import ColourizedFormatter
-
+import logging.config
+import structlog
 from murdock.config import GLOBAL_CONFIG
 
-LOGGER = logging.getLogger("murdock")
-LOGGER.setLevel(logging.getLevelName(GLOBAL_CONFIG.log_level))
+try:
+    from cysystemd import journal
+except ImportError:
+    journal = None
 
-formatter = ColourizedFormatter(
-    fmt=(
-        "%(levelprefix)-8s %(asctime)-15s - "
-        "%(filename)10s:%(lineno)-3d - %(message)s"
-    )
+
+# Pipeline used for all log messages
+common_processors = [
+    structlog.contextvars.merge_contextvars,
+    structlog.stdlib.add_logger_name,
+    structlog.stdlib.add_log_level,
+    structlog.processors.TimeStamper(fmt="iso"),
+    structlog.stdlib.PositionalArgumentsFormatter(),
+    structlog.processors.StackInfoRenderer(),
+]
+
+# Pipeline used with structlog messages
+structlog_processors = common_processors + [
+    structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+]
+
+structlog.configure(
+    processors=structlog_processors,
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    wrapper_class=structlog.make_filtering_bound_logger(
+        logging.getLevelName(GLOBAL_CONFIG.log_level)
+    ),
+    cache_logger_on_first_use=True,
 )
 
-handler = logging.StreamHandler()
-handler.setFormatter(formatter)
+log_handlers = {
+    "console": {
+        "formatter": "rich",
+        "class": "logging.StreamHandler",
+        "stream": "ext://sys.stderr",
+    },
+}
+if journal is not None:
+    log_handlers.update(
+        {
+            "journal": {
+                "formatter": "logfmt",
+                "()": journal.JournaldLogHandler,
+                "identifier": "murdock",
+            }
+        }
+    )
 
-LOGGER.addHandler(handler)
+
+stdlib_config = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "logfmt": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.processors.LogfmtRenderer(bool_as_flag=True),
+            "foreign_pre_chain": common_processors,
+        },
+        "rich": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.dev.ConsoleRenderer(),
+            "foreign_pre_chain": common_processors,
+        },
+    },
+    "handlers": log_handlers,
+    "loggers": {
+        "": {
+            "handlers": [GLOBAL_CONFIG.log_output],
+            "level": GLOBAL_CONFIG.log_level,
+            "propagate": True,
+        },
+    },
+}
+logging.config.dictConfig(stdlib_config)
+
+
+LOGGER = structlog.getLogger("murdock")

--- a/murdock/main.py
+++ b/murdock/main.py
@@ -57,6 +57,7 @@ LOGGER.debug(
     f"\nMurdock default:\n{json.dumps(MurdockSettings().dict(), indent=4)}\n"
 )
 
+
 murdock = Murdock(repository=GITHUB_CONFIG.repo)
 app = FastAPI(
     debug=GLOBAL_CONFIG.log_level == "DEBUG",
@@ -79,11 +80,11 @@ app.mount(
     StaticFiles(directory=GLOBAL_CONFIG.work_dir, html=True, check_dir=False),
     name="results",
 )
+murdock.instrumentator.instrument(app).expose(app)
 
 
 @app.on_event("startup")
 async def startup():
-    murdock.instrumentator.instrument(app).expose(app)
     await murdock.init()
 
 

--- a/murdock/tests/test_github.py
+++ b/murdock/tests/test_github.py
@@ -79,7 +79,7 @@ async def test_comment_on_pr_disabled(post, patch, get, job):
             True,
             False,
             1,
-            {"details": "error"},
+            '{"details": "error"}',
             id="not_sticky_comment_error",
         ),
         pytest.param(
@@ -119,7 +119,7 @@ async def test_comment_on_pr_disabled(post, patch, get, job):
             True,
             False,
             MAX_PAGES_COUNT,
-            {"details": "error"},
+            '{"details": "error"}',
             id="sticky_comment_creation_error",
         ),
         pytest.param(
@@ -159,7 +159,7 @@ async def test_comment_on_pr_disabled(post, patch, get, job):
             False,
             True,
             1,
-            {"details": "error"},
+            '{"details": "error"}',
             id="sticky_comment_update_error",
         ),
     ],
@@ -240,7 +240,8 @@ async def test_comment_on_pr(
         patch.assert_not_called()
 
     if error is not None:
-        assert f"<Response [401 Unauthorized]>: {error}" in caplog.text
+        assert "'response': '<Response [401 Unauthorized]>'" in caplog.text
+        assert f"'content': '{error}'" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -423,7 +424,8 @@ async def test_set_commit_status(post, caplog, code, text, status):
         content=json.dumps(status),
     )
     if code == 403:
-        assert f"<Response [403 Forbidden]>: {json.loads(text)}" in caplog.text
+        assert "'response': '<Response [403 Forbidden]>'" in caplog.text
+        assert f"'content': '{text}'" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/murdock/tests/test_job.py
+++ b/murdock/tests/test_job.py
@@ -186,9 +186,11 @@ def test_create_dir(tmpdir, caplog):
     new_dir = tmpdir.join("new").realpath()
     MurdockJob.create_dir(new_dir)
     assert os.path.exists(new_dir)
-    assert f"Creating directory '{new_dir}'" in caplog.text
+    assert "Creating work directory" in caplog.text
+    assert f"'dir': '{new_dir}'" in caplog.text
     MurdockJob.create_dir(new_dir)
-    assert f"Directory '{new_dir}' already exists, recreate" in caplog.text
+    assert "Directory already exists, recreating" in caplog.text
+    assert f"'dir': '{new_dir}'" in caplog.text
 
 
 def test_remove_dir(tmpdir, caplog):
@@ -197,12 +199,12 @@ def test_remove_dir(tmpdir, caplog):
     MurdockJob.create_dir(dir_to_remove)
     assert os.path.exists(dir_to_remove)
     MurdockJob.remove_dir(dir_to_remove)
-    assert f"Removing directory '{dir_to_remove}'" in caplog.text
-    assert (
-        f"Directory '{dir_to_remove}' doesn't exist, cannot remove"
-    ) not in caplog.text
+    assert "Removing work directory" in caplog.text
+    assert f"'dir': '{dir_to_remove}'" in caplog.text
+    assert "Work directory doesn't exist, cannot remove" not in caplog.text
     MurdockJob.remove_dir(dir_to_remove)
-    assert (f"Directory '{dir_to_remove}' doesn't exist, cannot remove") in caplog.text
+    assert ("Work directory doesn't exist, cannot remove") in caplog.text
+    assert f"'dir': '{dir_to_remove}'" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/murdock/tests/test_murdock.py
+++ b/murdock/tests/test_murdock.py
@@ -321,7 +321,8 @@ async def test_restart_job(fetch_config, schedule, job_found, caplog, murdock_mo
         fetch_config.assert_called_once()
         schedule.assert_called_once()
         schedule.call_args[0][0].commit == job_found.commit
-        assert f"Restarting {job_found}" in caplog.text
+        assert "Restarting job" in caplog.text
+        assert f"'job_description': '{job_found}'" in caplog.text
 
 
 pr_event = {
@@ -417,11 +418,13 @@ async def test_handle_pr_event_action(
     if allowed:
         fetch_config.assert_called_with(commit)
         fetch_commit.assert_called_with(commit)
-        assert f"Handle pull request event '{action}'" in caplog.text
+        assert "Handle pull request event" in caplog.text
+        assert f"'action': '{action}'" in caplog.text
     else:
         fetch_config.assert_not_called()
         fetch_commit.assert_not_called()
-        assert f"Handle pull request event '{action}'" not in caplog.text
+        assert "Handle pull request event" not in caplog.text
+        assert f"'action': '{action}'" not in caplog.text
 
     if queued_called:
         queued.assert_called_once()
@@ -429,10 +432,11 @@ async def test_handle_pr_event_action(
         queued.assert_not_called()
 
     if action == "closed":
-        assert "PR #123 closed, disabling matching jobs" in caplog.text
+        assert "PR closed, disabling matching jobs" in caplog.text
+        assert "'pr': '123'" in caplog.text
         disable.assert_called_once()
     else:
-        assert "PR #123 closed, disabling matching jobs" not in caplog.text
+        assert "PR closed, disabling matching jobs" not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -452,7 +456,7 @@ async def test_handle_pr_event_missing_commit_info(
     fetch_config.assert_not_called()
     fetch_commit.assert_called_once()
     assert "Handle pull request event" in caplog.text
-    assert "Cannot fetch commit information, aborting" in caplog.text
+    assert "'error': 'Cannot fetch commit information'" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -530,7 +534,7 @@ async def test_handle_pr_event_missing_ready_label(
     fetch_config.assert_called_once()
     fetch_commit.assert_called_once()
     assert "Handle pull request event" in caplog.text
-    assert f"'{CI_CONFIG.ready_label}' label not set" in caplog.text
+    assert "Required ready label not set" in caplog.text
     assert "Scheduling new job" not in caplog.text
 
 
@@ -665,7 +669,8 @@ async def test_handle_push_event(
     fetch_config.assert_called_with(commit)
     fetch_commit.assert_called_with(commit)
     queued.assert_called_once()
-    assert f"Handle push event on ref '{ref_name}'" in caplog.text
+    assert "Handle push event on ref" in caplog.text
+    assert f"'ref': '{ref_name}'" in caplog.text
     assert "Scheduling new job" in caplog.text
     assert "Cannot fetch commit information, aborting" not in caplog.text
 
@@ -717,7 +722,8 @@ async def test_handle_push_event_ref_not_handled(
     fetch_config.assert_called_with(commit)
     fetch_commit.assert_called_with(commit)
     queued.assert_not_called()
-    assert f"Ref '{ref_name}' not accepted for push events" in caplog.text
+    assert "Ref not accepted for push events" in caplog.text
+    assert f"'ref': '{ref_name}'" in caplog.text
     assert f"Handle push event on ref '{ref_name}'" not in caplog.text
     assert "Scheduling new job" not in caplog.text
 
@@ -794,7 +800,8 @@ async def test_handle_push_event_skip_commit(
     fetch_config.assert_called_with(commit)
     fetch_commit.assert_called_with(commit)
     assert f"Ref '{branch}' not accepted for push events" not in caplog.text
-    assert f"Handle push event on ref '{branch}'" in caplog.text
+    assert "Handle push event on ref" in caplog.text
+    assert f"'ref': '{branch}'" in caplog.text
     assert "Scheduling new job" in caplog.text
     if skipped is False:
         commit_status.assert_not_called()
@@ -837,7 +844,8 @@ async def test_handle_push_event_ref_removed(
     fetch_config.assert_not_called()
     fetch_commit.assert_not_called()
     queued.assert_not_called()
-    assert f"Handle push event on ref '{branch}'" not in caplog.text
+    assert "Handle push event on ref" not in caplog.text
+    assert f"'ref': '{branch}'" not in caplog.text
     assert "Scheduling new job" not in caplog.text
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ aiosmtplib
 prometheus-fastapi-instrumentator
 asyncpg
 orjson
+structlog
+cysystemd


### PR DESCRIPTION
This commit rewrites the logging in the application to structured log
format. A pretty console printing and direct systemd-journal are available.
The logging can be switched via the MURDOCK_LOG_OUTPUT environment
variable. It defaults to `console` for development. Setting it to
`journal` sets it to output to the systemd journal.