### PR TITLE
 postgresql: Fix update query for jsonb field 

### DIFF
--- a/murdock/tests/test_database_postgresql.py
+++ b/murdock/tests/test_database_postgresql.py
@@ -58,6 +58,13 @@ async def test_database_postgres(caplog):
     search_jobs = await db.find_jobs(JobQueryModel(prnum=prnum))
     assert search_jobs[0].commit.sha == "456"
 
+    assert (
+        await db.update_jobs(JobQueryModel(prnum=prnum), "prinfo.title", "new title")
+        == 1
+    )
+    search_jobs = await db.find_jobs(JobQueryModel(prnum=prnum))
+    assert search_jobs[0].prinfo.title == "new title"
+
     await db.delete_jobs(JobQueryModel(prnum=prnum))
     assert len(await db.find_jobs(JobQueryModel(prnum=prnum))) == 0
 


### PR DESCRIPTION
This fixes the query when the `update_jobs` function is called to update the data inside the `jsonb` prinfo field (which is always the case). It also extends the postgres tests to prevent regressions.