### PR TITLE
compose: Include murdock.py in the volume binds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
       - /usr/bin/docker:/usr/bin/docker
       - /run/systemd/journal/socket:/run/systemd/journal/socket
       - ./murdock:/var/lib/murdock/murdock
+      - ./murdock.py:/var/lib/murdock/murdock.py
       - ${MURDOCK_WORK_DIR}:/var/lib/murdock-data
       - ${MURDOCK_SCRIPTS_DIR}:/var/lib/murdock-scripts
     logging:


### PR DESCRIPTION
Kind of useful when trying to start the frontend by calling the `murdock.py` application