### PR TITLE
github: don't log full comment response from github

### DIFF
--- a/murdock/github.py
+++ b/murdock/github.py
@@ -128,9 +128,9 @@ async def comment_on_pr(job: MurdockJob):
                 headers=request_headers,
                 content=request_data,
             )
-        logger = logger.bind(response=str(response), content=str(response.text))
+        logger = logger.bind(response=str(response))
         if response.status_code != 200:
-            logger.error("Failed to put comment on PR")
+            logger.error("Failed to put comment on PR", content=str(response.text))
         else:
             logger.info("Comment posted on PR")
 


### PR DESCRIPTION
This removes the content of the response from github after posting a reply to a topic. It still logs the content after an error. In case of success the full json of the post is in the reply which is quite a lot of data to log while it doesn't add anything