### PR TITLE
postgresql: Reduce logging of terminated connections

### DIFF
--- a/murdock/database/postgresql.py
+++ b/murdock/database/postgresql.py
@@ -216,7 +216,7 @@ class PostgresDatabase(Database):
         conn.add_termination_listener(self._termination_listener)
 
     def _termination_listener(self, conn):
-        self._logger.warning("Lost connection to PostgreSQL database", conn=conn)
+        self._logger.info("Closed connection to PostgreSQL database", conn=conn)
 
     async def init(self):
         self._logger.info("Connecting to postgres")


### PR DESCRIPTION
Another small tuning of log messages

The terminate_connection callback is called on any closed connection to the database, also when the connection pool closes a connection by itself. This is thus not an issue and should not be logged at warning level