### PR TITLE
metrics: Exclude from schema info

### DIFF
--- a/murdock/main.py
+++ b/murdock/main.py
@@ -80,7 +80,7 @@ app.mount(
     StaticFiles(directory=GLOBAL_CONFIG.work_dir, html=True, check_dir=False),
     name="results",
 )
-murdock.instrumentator.instrument(app).expose(app)
+murdock.instrumentator.instrument(app).expose(app, include_in_schema=False)
 
 
 @app.on_event("startup")


### PR DESCRIPTION
No need to show this endpoint in the api info