### PR TITLE
job: Make create_dir an instance method

### DIFF
--- a/murdock/job.py
+++ b/murdock/job.py
@@ -70,16 +70,15 @@ class MurdockJob:
             self._logger_context["pr"] = str(self.pr.number)
         self._logger = LOGGER.bind(**self._logger_context)
 
-    @staticmethod
-    def create_dir(work_dir: str) -> None:
-        logger = LOGGER.bind(dir=str(work_dir))
+    def create_dir(self) -> None:
+        logger = self._logger.bind(dir=str(self.work_dir))
         try:
             logger.info("Creating work directory")
-            os.makedirs(work_dir)
+            os.makedirs(self.work_dir)
         except FileExistsError:
             logger.info("Directory already exists, recreating")
-            shutil.rmtree(work_dir)
-            os.makedirs(work_dir)
+            shutil.rmtree(self.work_dir)
+            os.makedirs(self.work_dir)
 
     @staticmethod
     def remove_dir(work_dir):
@@ -251,7 +250,7 @@ class MurdockJob:
         return dict(self._logger_context)
 
     async def exec(self, notify: Callable) -> None:
-        MurdockJob.create_dir(self.work_dir)
+        self.create_dir()
         self._logger.debug("Starting execution")
 
         self.notify = notify

--- a/murdock/tests/test_job.py
+++ b/murdock/tests/test_job.py
@@ -184,11 +184,13 @@ def test_basic(capsys, pr, ref, config, out, env):
 def test_create_dir(tmpdir, caplog):
     caplog.set_level(logging.DEBUG, logger="murdock")
     new_dir = tmpdir.join("new").realpath()
-    MurdockJob.create_dir(new_dir)
+    job = MurdockJob(commit)
+    job.work_dir = new_dir
+    job.create_dir()
     assert os.path.exists(new_dir)
     assert "Creating work directory" in caplog.text
     assert f"'dir': '{new_dir}'" in caplog.text
-    MurdockJob.create_dir(new_dir)
+    job.create_dir()
     assert "Directory already exists, recreating" in caplog.text
     assert f"'dir': '{new_dir}'" in caplog.text
 
@@ -196,7 +198,10 @@ def test_create_dir(tmpdir, caplog):
 def test_remove_dir(tmpdir, caplog):
     caplog.set_level(logging.DEBUG, logger="murdock")
     dir_to_remove = tmpdir.join("remove").realpath()
-    MurdockJob.create_dir(dir_to_remove)
+
+    job = MurdockJob(commit)
+    job.work_dir = dir_to_remove
+    job.create_dir()
     assert os.path.exists(dir_to_remove)
     MurdockJob.remove_dir(dir_to_remove)
     assert "Removing work directory" in caplog.text


### PR DESCRIPTION
It is a bit harder to do the same with the remove dir function due to how it is used.