### PR TITLE
Deployment: Fix minor versioning issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,4 +133,4 @@ MURDOCK_HTML_DIR=./murdock-html
 ## uvicorn access log logging level. Controls logging of endpoint access. These
 ## are logged at INFO level. Anything above suppresses logging of the individual
 ## endpoint access requests by clients.
-UVICORN_LOG_LEVEL=info
+UVICORN_LOG_LEVEL=INFO

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 LABEL maintainer="alexandre.abadie@inria.fr"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
         - MURDOCK_NOTIFIER_MAIL_PASSWORD
         - MURDOCK_NOTIFIER_MATRIX_ROOM
         - MURDOCK_NOTIFIER_MATRIX_TOKEN
-        - UVICORN_LOG_LEVEL=info
+        - UVICORN_LOG_LEVEL=INFO
         - CI_READY_LABEL
         - CI_FASTTRACK_LABELS
     volumes:
@@ -130,7 +130,7 @@ services:
       - ${MURDOCK_PORT}:8081
       - 9982:9982
     volumes:
-      - ${PWD}/traefik:/etc/traefik
+      - ./traefik:/etc/traefik
     environment:
       - MURDOCK_PROJECT=${COMPOSE_PROJECT_NAME}
     logging:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ prometheus-fastapi-instrumentator
 asyncpg
 orjson
 structlog
+pydantic == 1.10
 cysystemd


### PR DESCRIPTION
Hi 🦤,

this fixes some issues that prevented `make` to work.

1. The log level needs to be capital. Otherwise the logging initialization will fail.
2. Pinning the container os: Two weeks in a row, ubuntu:latest did not work for me. Today it started working again...anyway, we can pin to a LTS version.
3. pydantic 2.0 did a big rework and I think it is no longer compatible? I guessed this version and could only do limited testing :/ if other maintainers could check which version is running on their machines, that would be great!
4. PWD is the only absolute value in the compose file. Replacing it with a relative path to be in line with the rest. (This one gave me a headache)