### PR TITLE
CI: Pin ubuntu version

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -39,7 +39,7 @@ jobs:
       if: matrix.python-version == 3.10
       run: bash <(curl -s https://codecov.io/bash)
   docker-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@master
     - run: |


### PR DESCRIPTION
Hi 🦘

This pins the ubuntu version of the docker used in the ci to a known value. This is needed to fix the ci for #54 